### PR TITLE
Skip create ChangeSet when there are no changes to deploy

### DIFF
--- a/lib/createChangeSet.js
+++ b/lib/createChangeSet.js
@@ -49,6 +49,11 @@ module.exports = {
     const stackName = this.provider.naming.getStackName()
     const changeSetName = this.options.changeSetName ? this.options.changeSetName : `${stackName}-${Date.now()}`
 
+    if (this.shouldNotDeploy) {
+      this.serverless.cli.log('Skip create ChangeSet', 'Serverless', { color: 'orange' });
+      return Promise.resolve();
+    }
+
     this.serverless.cli.log(`Creating CloudFormation ChangeSet [${changeSetName}]...`)
     return createChangeSet(this, stackName, changeSetName, 'UPDATE')
       .catch(e => {

--- a/lib/createChangeSet.js
+++ b/lib/createChangeSet.js
@@ -50,7 +50,7 @@ module.exports = {
     const changeSetName = this.options.changeSetName ? this.options.changeSetName : `${stackName}-${Date.now()}`
 
     if (this.shouldNotDeploy) {
-      this.serverless.cli.log('Skip create ChangeSet', 'Serverless', { color: 'orange' });
+      this.serverless.cli.log('Skipping create ChangeSet...', 'Serverless', { color: 'orange' });
       return Promise.resolve();
     }
 

--- a/lib/createChangeSet.test.js
+++ b/lib/createChangeSet.test.js
@@ -134,13 +134,13 @@ describe('updateStack', () => {
         })
     })
 
-      it('should skip create ChangeSet if should not deploy', () => {
-          serverlessChangeSets.shouldNotDeploy = true
+    it('should skip create ChangeSet if should not deploy', () => {
+      serverlessChangeSets.shouldNotDeploy = true
 
-          return createChangeSet.bind(serverlessChangeSets)()
-              .then(() => {
-                  sinon.assert.notCalled(createChangeSetStub)
-              })
-      })
+      return createChangeSet.bind(serverlessChangeSets)()
+        .then(() => {
+          sinon.assert.notCalled(createChangeSetStub)
+        })
     })
   })
+})

--- a/lib/createChangeSet.test.js
+++ b/lib/createChangeSet.test.js
@@ -133,5 +133,14 @@ describe('updateStack', () => {
           )
         })
     })
+
+      it('should skip create ChangSet if should not deploy', () => {
+          serverlessChangeSets.shouldNotDeploy = true
+
+          return createChangeSet.bind(serverlessChangeSets)()
+              .then(() => {
+                  sinon.assert.notCalled(createChangeSetStub)
+              })
+      })
+    })
   })
-})

--- a/lib/createChangeSet.test.js
+++ b/lib/createChangeSet.test.js
@@ -134,7 +134,7 @@ describe('updateStack', () => {
         })
     })
 
-      it('should skip create ChangSet if should not deploy', () => {
+      it('should skip create ChangeSet if should not deploy', () => {
           serverlessChangeSets.shouldNotDeploy = true
 
           return createChangeSet.bind(serverlessChangeSets)()


### PR DESCRIPTION
When there are no changes to the lambdas or cloudformation template the plugin returns an S3 error because it tries to get the template from S3. The template doesn’t exist because a previous step detected no changes and skips deployment.

Issue can be reproduced by only changing README.

My fix skips creating a ChangeSet if there are no changes to deploy.

Before
![image](https://user-images.githubusercontent.com/13135091/88940483-16e96080-d288-11ea-9942-21f7bc80663f.png)

After
![image](https://user-images.githubusercontent.com/13135091/88941393-3df46200-d289-11ea-9e6d-f8559f2bb983.png)

